### PR TITLE
Feat/#5 index page

### DIFF
--- a/src/components/indexPage/IndexComponent.jsx
+++ b/src/components/indexPage/IndexComponent.jsx
@@ -1,5 +1,28 @@
-const IndexComponent = () => {
-  return <div>IndexComponent</div>;
+import { useNavigate } from "react-router-dom";
+
+const IndexComponent = ({ data, setBackgroundColor }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className="index-wrap"
+      onClick={() => navigate(`/index/${data?.link}`)}
+      onMouseOver={() => setBackgroundColor("#000")}
+      onMouseLeave={() => setBackgroundColor("#fff")}
+    >
+      <div className="left-wrap">
+        <span className="number">{data?.number}</span>
+        <span className="title">{data?.title}</span>
+      </div>
+      <div className="right-wrap">
+        <div className="content-wrap">
+          <div className="period">{data?.period}</div>
+          <div className="middle-line">-</div>
+          <div className="description">{data?.description}</div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default IndexComponent;

--- a/src/components/indexPage/IndexComponent.jsx
+++ b/src/components/indexPage/IndexComponent.jsx
@@ -1,0 +1,5 @@
+const IndexComponent = () => {
+  return <div>IndexComponent</div>;
+};
+
+export default IndexComponent;

--- a/src/components/indexPage/IndexComponent.jsx
+++ b/src/components/indexPage/IndexComponent.jsx
@@ -1,14 +1,25 @@
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+
+import { ReactComponent as ArrowSvg } from "../../assets/icon/arrow_black.svg";
 
 const IndexComponent = ({ data, setBackgroundColor }) => {
   const navigate = useNavigate();
+
+  const [hover, setHover] = useState(false);
 
   return (
     <div
       className="index-wrap"
       onClick={() => navigate(`/index/${data?.link}`)}
-      onMouseOver={() => setBackgroundColor("#000")}
-      onMouseLeave={() => setBackgroundColor("#fff")}
+      onMouseOver={() => {
+        setBackgroundColor("#000");
+        setHover(true);
+      }}
+      onMouseLeave={() => {
+        setBackgroundColor("#fff");
+        setHover(false);
+      }}
     >
       <div className="left-wrap">
         <span className="number">{data?.number}</span>
@@ -20,6 +31,7 @@ const IndexComponent = ({ data, setBackgroundColor }) => {
           <div className="middle-line">-</div>
           <div className="description">{data?.description}</div>
         </div>
+        {hover && <ArrowSvg className="arrow-icon-2" />}
       </div>
     </div>
   );

--- a/src/components/indexPage/IndexComponent.jsx
+++ b/src/components/indexPage/IndexComponent.jsx
@@ -1,6 +1,8 @@
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 
+import useScrollFadeIn from "../../hooks/useScrollFadeIn";
+
 import { ReactComponent as ArrowSvg } from "../../assets/icon/arrow_black.svg";
 
 const IndexComponent = ({ data, setBackgroundColor }) => {
@@ -20,6 +22,7 @@ const IndexComponent = ({ data, setBackgroundColor }) => {
         setBackgroundColor("#fff");
         setHover(false);
       }}
+      {...useScrollFadeIn("up", 1, 0)}
     >
       <div className="left-wrap">
         <span className="number">{data?.number}</span>

--- a/src/hooks/useScrollFadeIn.jsx
+++ b/src/hooks/useScrollFadeIn.jsx
@@ -1,0 +1,53 @@
+import { useRef, useEffect, useCallback } from "react";
+
+const useScrollFadeIn = (direction = "up", duration = 1, delay = 0) => {
+  const element = useRef();
+
+  const handleDirection = (name) => {
+    switch (name) {
+      case "up":
+        return "translate3d(0, 50%, 0)";
+      case "down":
+        return "translate3d(0, -50%, 0)";
+      case "left":
+        return "translate3d(50%, 0, 0)";
+      case "right":
+        return "translate3d(-50%, 0, 0)";
+      default:
+        return;
+    }
+  };
+
+  const onScroll = useCallback(
+    ([entry]) => {
+      const { current } = element;
+      if (entry.isIntersecting) {
+        current.style.transitionProperty = "all";
+        current.style.transitionDuration = `${duration}s`;
+        current.style.transitionTimingFunction = "cubic-bezier(0, 0, 0.2, 1)";
+        current.style.transitionDelay = `${delay}s`;
+        current.style.opacity = 1;
+        current.style.transform = "translate3d(0, 0, 0)";
+      }
+    },
+    [delay, duration]
+  );
+
+  useEffect(() => {
+    let observer;
+
+    if (element.current) {
+      observer = new IntersectionObserver(onScroll, { threshold: 0.7 });
+      observer.observe(element.current);
+    }
+
+    return () => observer && observer.disconnect();
+  }, [onScroll]);
+
+  return {
+    ref: element,
+    style: { opacity: 0, transform: handleDirection(direction) },
+  };
+};
+
+export default useScrollFadeIn;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import "./styles/startPage.scss";
+import "./styles/indexPage.scss";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
-import "./styles/startPage.scss";
-import "./styles/indexPage.scss";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
+import "./styles/startPage.scss";
+import "./styles/indexPage.scss";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/pages/IndexPage.jsx
+++ b/src/pages/IndexPage.jsx
@@ -20,22 +20,29 @@ const IndexPage = () => {
           onMouseLeave={() => setBackgroundColor("#fff")}
         />
       </div>
-      {IndexData.map((data) => {
-        return (
-          <IndexComponent
-            number={data.number}
-            title={data.title}
-            period={data.period}
-            description={data.description}
-            link={data.link}
-            key={data.number}
-          />
-        );
-      })}
+      <IndexComponent
+        data={IndexData[0]}
+        setBackgroundColor={setBackgroundColor}
+      />
+      <IndexComponent
+        data={IndexData[1]}
+        setBackgroundColor={setBackgroundColor}
+      />
+      <IndexComponent
+        data={IndexData[2]}
+        setBackgroundColor={setBackgroundColor}
+      />
+      <IndexComponent
+        data={IndexData[3]}
+        setBackgroundColor={setBackgroundColor}
+      />
+      <IndexComponent
+        data={IndexData[4]}
+        setBackgroundColor={setBackgroundColor}
+      />
     </div>
   );
 };
-
 // 목차 데이터
 const IndexData = [
   {
@@ -44,6 +51,35 @@ const IndexData = [
     period: "2023.01.02 - 2023.04.28",
     description: `래브라도랩스는 소스코드, 바이너리, 컨테이너에 대한 취약점을 분석하고 수정하는 소프트웨어 구성 분석 솔루션인 'Labrador' 플랫폼을 개발하는 회사이다. 인턴으로 4개월 동안 프론트팀에서 프론트엔드 개발과 UI 디자인 업무를 맡으며 Labrador의 페이지 디자인 및 개발, UI 컴포넌트 수정 및 코드 적용, Labrador의 삼성화재 버전인 IVAS의 UI 개선 업무를 진행했다.`,
     link: 1,
+  },
+  {
+    number: "02",
+    title: "APP Project",
+    period: "2023.07.02 -",
+    description: `'대학생 모임 기반 커뮤니티 앱 개발, Flint'를 주제로 하는 앱 프로젝트이다. 해당 프로젝트에서 프론트엔드 개발자와 UI 보조 디자이너로 활약했다. React Native를 이용하여 앱 내의 페이지들을 개발하고 로고 및 아이콘 등의 그래픽 요소들을 디자인 및 페이지 디자인에 대한 피드백을 맡았다.`,
+    link: 2,
+  },
+  {
+    number: "03",
+    title: "Ajou Paran Project",
+    period: "2022.03.02 - 2022.06.17",
+    description: `파란학기제는 학생 스스로 도전과제를 설계하여 실천하는 아주대학교의 학점 인정 프로젝트이다. '아주대학교 개발자들을 위한 커뮤니티 웹사이트 Cola 개발'을 주제로 팀 내에서 그래픽 및 UI 디자인과 메인 페이지 개발을 맡았다. 로고와 캐릭터 디자인 그리고 UI 디자인을 주요 업무로 진행하며 페이지 개발을 경험해볼 수 있었다.`,
+    link: 3,
+  },
+  {
+    number: "04",
+    title: "Mini Project",
+    period: "2023.05.10 - 2022.05.12",
+    description: `'일상을 기록하는 나만의 캘린더'를 주제로 3일 동안 간단하게 진행한 프로젝트이다. 하루의 기분을 이모티콘으로 달력에 표시하고, 투두리스트 및 일기 작성의 기능이 주 기능이었다. 프론트엔드 개발을 물론 MongoDB를 활용하여 간단한 백엔드 작업까지 진행하였다. 기획부터 UI 와이어프레임 및 디자인, 프론트엔드 및 백엔드 개발까지 전 과정을 진행했다.`,
+    link: 4,
+  },
+  {
+    number: "05",
+    title: "ETC : Design",
+    period: "2019 - 2023",
+    description:
+      "프론트엔드 개발과 외에도 다양한 디자인 경험을 갖춤으로써 단순히 만들어진 디자인을 구현하는 프론트엔드 개발자가 아닌 디자인에 의견을 제시하고 개선할 수 있는 프론트엔드 개발자가 되고자 하였다.",
+    link: 5,
   },
 ];
 

--- a/src/pages/IndexPage.jsx
+++ b/src/pages/IndexPage.jsx
@@ -1,13 +1,23 @@
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+
 import { ReactComponent as ArrowSvg } from "../assets/icon/arrow_black.svg";
 
 const IndexPage = () => {
   const navigate = useNavigate();
 
+  // container 배경색 지정 state
+  const [backgroundColor, setBackgroundColor] = useState("#fff");
+
   return (
-    <div className="container2">
+    <div className="container2" style={{ backgroundColor: backgroundColor }}>
       <div className="arrow-wrap">
-        <ArrowSvg className="arrow-icon" onClick={() => navigate("/")} />
+        <ArrowSvg
+          className="arrow-icon"
+          onClick={() => navigate("/")}
+          onMouseOver={() => setBackgroundColor("#000")}
+          onMouseLeave={() => setBackgroundColor("#fff")}
+        />
       </div>
     </div>
   );

--- a/src/pages/IndexPage.jsx
+++ b/src/pages/IndexPage.jsx
@@ -1,12 +1,13 @@
+import { useNavigate } from "react-router-dom";
 import { ReactComponent as ArrowSvg } from "../assets/icon/arrow_black.svg";
 
-import "../styles/indexPage.scss";
-
 const IndexPage = () => {
+  const navigate = useNavigate();
+
   return (
-    <div className="container">
-      <div className="back-btn-wrap">
-        <ArrowSvg className="arrow-icon" />
+    <div className="container2">
+      <div className="arrow-wrap">
+        <ArrowSvg className="arrow-icon" onClick={() => navigate("/")} />
       </div>
     </div>
   );

--- a/src/pages/IndexPage.jsx
+++ b/src/pages/IndexPage.jsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 
 import { ReactComponent as ArrowSvg } from "../assets/icon/arrow_black.svg";
+import IndexComponent from "../components/IndexPage/IndexComponent";
 
 const IndexPage = () => {
   const navigate = useNavigate();
@@ -19,8 +20,31 @@ const IndexPage = () => {
           onMouseLeave={() => setBackgroundColor("#fff")}
         />
       </div>
+      {IndexData.map((data) => {
+        return (
+          <IndexComponent
+            number={data.number}
+            title={data.title}
+            period={data.period}
+            description={data.description}
+            link={data.link}
+            key={data.number}
+          />
+        );
+      })}
     </div>
   );
 };
+
+// 목차 데이터
+const IndexData = [
+  {
+    number: "01",
+    title: "LabradorLabs Intern",
+    period: "2023.01.02 - 2023.04.28",
+    description: `래브라도랩스는 소스코드, 바이너리, 컨테이너에 대한 취약점을 분석하고 수정하는 소프트웨어 구성 분석 솔루션인 'Labrador' 플랫폼을 개발하는 회사이다. 인턴으로 4개월 동안 프론트팀에서 프론트엔드 개발과 UI 디자인 업무를 맡으며 Labrador의 페이지 디자인 및 개발, UI 컴포넌트 수정 및 코드 적용, Labrador의 삼성화재 버전인 IVAS의 UI 개선 업무를 진행했다.`,
+    link: 1,
+  },
+];
 
 export default IndexPage;

--- a/src/pages/IndexPage.jsx
+++ b/src/pages/IndexPage.jsx
@@ -1,14 +1,13 @@
-import { Link, useNavigate } from "react-router-dom";
+import { ReactComponent as ArrowSvg } from "../assets/icon/arrow_black.svg";
+
+import "../styles/indexPage.scss";
 
 const IndexPage = () => {
-  const navigate = useNavigate();
-
   return (
-    <div>
-      <button onClick={() => navigate(-1)}>뒤로가기</button>
-      <Link to={"1"}>목차1</Link>
-      <Link to={"2"}>목차2</Link>
-      <Link to={"3"}>목차3</Link>
+    <div className="container">
+      <div className="back-btn-wrap">
+        <ArrowSvg className="arrow-icon" />
+      </div>
     </div>
   );
 };

--- a/src/pages/StartPage.jsx
+++ b/src/pages/StartPage.jsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 import { ReactComponent as ArrowSvg } from "../assets/icon/arrow_black.svg";
 import { useNavigate } from "react-router-dom";
 
+import "../styles/startPage.scss";
+
 const StartPage = () => {
   const navigate = useNavigate();
 

--- a/src/styles/indexPage.scss
+++ b/src/styles/indexPage.scss
@@ -1,0 +1,15 @@
+.container2 {
+  background-color: #fff !important;
+  width: 100vw;
+  height: 100vh;
+  padding: 5%;
+  box-sizing: border-box;
+
+  .arrow-wrap {
+    .arrow-icon {
+      fill: #000;
+      cursor: pointer;
+      width: 10%;
+    }
+  }
+}

--- a/src/styles/indexPage.scss
+++ b/src/styles/indexPage.scss
@@ -1,15 +1,20 @@
 .container2 {
-  background-color: #fff !important;
   width: 100vw;
   height: 100vh;
   padding: 5%;
   box-sizing: border-box;
+  transition: background-color 0.3s ease-in;
 
   .arrow-wrap {
     .arrow-icon {
       fill: #000;
       cursor: pointer;
       width: 10%;
+      transition: fill 0.3s ease-in;
+
+      &:hover {
+        fill: #fff;
+      }
     }
   }
 }

--- a/src/styles/indexPage.scss
+++ b/src/styles/indexPage.scss
@@ -6,14 +6,77 @@
   transition: background-color 0.3s ease-in;
 
   .arrow-wrap {
+    margin-bottom: 2.5%;
+
     .arrow-icon {
       fill: #000;
       cursor: pointer;
-      width: 10%;
+      width: 8%;
       transition: fill 0.3s ease-in;
 
       &:hover {
         fill: #fff;
+      }
+    }
+  }
+  .link-wrap {
+    text-decoration: none;
+
+    .index-wrap {
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      color: #000;
+
+      &:hover {
+        color: #fff !important;
+      }
+      .left-wrap {
+        display: flex;
+        flex-direction: column;
+
+        .number {
+          font-family: "Unbounded", cursive;
+          color: inherit;
+          font-size: 5vw;
+          line-height: 1.2;
+        }
+        .title {
+          width: max-content;
+          color: inherit;
+          font-size: 3.5vw;
+          font-weight: 600;
+          line-height: 1.2;
+        }
+      }
+      .right-wrap {
+        display: flex;
+        flex-direction: row;
+
+        .content-wrap {
+          display: flex;
+          flex-direction: column;
+          align-items: end;
+          width: 35vw;
+
+          .period {
+            color: inherit;
+            font-size: 1.2vw;
+            font-weight: 600;
+          }
+          .middle-line {
+            font-size: 3.5vw;
+            line-height: 0.8;
+            color: inherit;
+          }
+          .description {
+            color: inherit;
+            font-size: 1vw;
+            font-weight: 500;
+            text-align: end;
+          }
+        }
       }
     }
   }

--- a/src/styles/indexPage.scss
+++ b/src/styles/indexPage.scss
@@ -19,63 +19,59 @@
       }
     }
   }
-  .link-wrap {
-    text-decoration: none;
+  .index-wrap {
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: #000;
 
-    .index-wrap {
-      cursor: pointer;
+    &:hover {
+      color: #fff !important;
+    }
+    .left-wrap {
       display: flex;
-      justify-content: space-between;
-      align-items: center;
-      color: #000;
+      flex-direction: column;
 
-      &:hover {
-        color: #fff !important;
+      .number {
+        font-family: "Unbounded", cursive;
+        color: inherit;
+        font-size: 5vw;
+        line-height: 1.2;
       }
-      .left-wrap {
+      .title {
+        width: max-content;
+        color: inherit;
+        font-size: 3.5vw;
+        font-weight: 600;
+        line-height: 1.2;
+      }
+    }
+    .right-wrap {
+      display: flex;
+      flex-direction: row;
+
+      .content-wrap {
         display: flex;
         flex-direction: column;
+        align-items: end;
+        width: 35vw;
 
-        .number {
-          font-family: "Unbounded", cursive;
+        .period {
           color: inherit;
-          font-size: 5vw;
-          line-height: 1.2;
-        }
-        .title {
-          width: max-content;
-          color: inherit;
-          font-size: 3.5vw;
+          font-size: 1.2vw;
           font-weight: 600;
-          line-height: 1.2;
         }
-      }
-      .right-wrap {
-        display: flex;
-        flex-direction: row;
-
-        .content-wrap {
-          display: flex;
-          flex-direction: column;
-          align-items: end;
-          width: 35vw;
-
-          .period {
-            color: inherit;
-            font-size: 1.2vw;
-            font-weight: 600;
-          }
-          .middle-line {
-            font-size: 3.5vw;
-            line-height: 0.8;
-            color: inherit;
-          }
-          .description {
-            color: inherit;
-            font-size: 1vw;
-            font-weight: 500;
-            text-align: end;
-          }
+        .middle-line {
+          font-size: 3.5vw;
+          line-height: 0.8;
+          color: inherit;
+        }
+        .description {
+          color: inherit;
+          font-size: 1vw;
+          font-weight: 500;
+          text-align: end;
         }
       }
     }

--- a/src/styles/indexPage.scss
+++ b/src/styles/indexPage.scss
@@ -1,17 +1,18 @@
 .container2 {
   width: 100vw;
-  height: 100vh;
-  padding: 5%;
+  height: max-content;
+  padding: 5% 6%;
   box-sizing: border-box;
   transition: background-color 0.3s ease-in;
 
   .arrow-wrap {
-    margin-bottom: 2.5%;
+    margin-bottom: 5%;
 
     .arrow-icon {
       fill: #000;
       cursor: pointer;
       width: 8%;
+      height: max-content;
       transition: fill 0.3s ease-in;
 
       &:hover {
@@ -25,9 +26,13 @@
     justify-content: space-between;
     align-items: center;
     color: #000;
+    margin-bottom: 10%;
 
     &:hover {
       color: #fff !important;
+    }
+    &:last-child {
+      margin-bottom: 0;
     }
     .left-wrap {
       display: flex;
@@ -38,6 +43,7 @@
         color: inherit;
         font-size: 5vw;
         line-height: 1.2;
+        margin-bottom: 3%;
       }
       .title {
         width: max-content;
@@ -48,14 +54,18 @@
       }
     }
     .right-wrap {
+      width: max-content;
       display: flex;
       flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10%;
 
       .content-wrap {
+        width: 28vw;
         display: flex;
         flex-direction: column;
         align-items: end;
-        width: 35vw;
 
         .period {
           color: inherit;
@@ -63,7 +73,7 @@
           font-weight: 600;
         }
         .middle-line {
-          font-size: 3.5vw;
+          font-size: 3vw;
           line-height: 0.8;
           color: inherit;
         }
@@ -73,6 +83,11 @@
           font-weight: 500;
           text-align: end;
         }
+      }
+      .arrow-icon-2 {
+        fill: #fff;
+        width: 5vw;
+        transform: rotate(180deg);
       }
     }
   }

--- a/src/styles/startPage.scss
+++ b/src/styles/startPage.scss
@@ -4,13 +4,13 @@
   box-sizing: border-box;
 }
 .container {
+  background-color: #000 !important;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   width: 100vw;
   height: 100vh;
-  background-color: #000;
 
   .circle {
     position: absolute;


### PR DESCRIPTION
## 관련 이슈
#5 
## 변경 사항
 - 하나의 목차를 보여주는 컴포넌트 생성
 - 목차 컴포넌트 목차 페이지에 적용
 - 스크롤 하여 해당 목차가 보이는 경우 fadeIn 애니메이션 적용
 - 각 목차에서 상세 페이지로의 이동 구현
## 스크린샷
<img width="1069" alt="스크린샷 2023-09-11 오후 3 03 52" src="https://github.com/2-hs2/portfolio/assets/109052496/248c7700-4149-4cb8-aa11-38bb8aeca93b">

## 추후 계획
상세 페이지 제작
## 기타
useScrollFadeIn 훅 참고
https://darrengwon.tistory.com/1179